### PR TITLE
Pin to Rust 1.31 on CircleCI and update cargo fmt call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:latest
+      - image: rust:1.31
     steps:
       - checkout
-      - run: rustup component add rustfmt-preview
+      - run: rustup component add rustfmt
       - run: cargo build
       - run: cargo test
-      - run: cargo fmt -- --write-mode=diff
+      - run: cargo fmt -- --check

--- a/examples/read_frame.rs
+++ b/examples/read_frame.rs
@@ -1,8 +1,8 @@
 extern crate lin_bus_driver_serial;
 
-use lin_bus_driver_serial::SerialLin;
-use lin_bus_driver_serial::serial as serial;
 use lin_bus_driver_serial::lin_bus::{Master, PID};
+use lin_bus_driver_serial::serial;
+use lin_bus_driver_serial::SerialLin;
 
 fn main() {
     let pid = PID::from_id(42);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,10 @@ impl From<SerialError> for driver::Error {
     fn from(error: SerialError) -> driver::Error {
         match error {
             SerialError::LinError(lin_error) => lin_error,
-            SerialError::SerialError(ser_error) => {
-                match ser_error.kind() {
-                    serial::ErrorKind::Io(std::io::ErrorKind::TimedOut) => driver::Error::Timeout,
-                    _ => driver::Error::PhysicalBus,
-                }
-            }
+            SerialError::SerialError(ser_error) => match ser_error.kind() {
+                serial::ErrorKind::Io(std::io::ErrorKind::TimedOut) => driver::Error::Timeout,
+                _ => driver::Error::PhysicalBus,
+            },
         }
     }
 }


### PR DESCRIPTION
The rustfmt component is not a preview anymore and it supports a check
mode. Also the default formatting rules changed so we adapt to them as
well.