### PR TITLE
Always write all data to serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows [semantic versioning](https://semver.org/).
 
  * changed: Depend on lin-bus crate 0.4
  * breaking: Minimal required Rust version changed to 1.57.0
+ * fixed: Always write data completly
+   ([#14](https://github.com/Sensirion/lin-bus-driver-serial-rs/pull/14))
 
 ## [0.3.0] (2019-07-16)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl driver::Master for SerialLin {
             Ok(())
         })?;
 
-        self.0.write(&[0])?;
+        self.0.write_all(&[0])?;
         let mut buf = [0; 1];
         self.0.read_exact(&mut buf)?;
 
@@ -84,7 +84,7 @@ impl driver::Master for SerialLin {
             Ok(())
         })?;
 
-        self.0.write(&[0])?;
+        self.0.write_all(&[0])?;
         // wait a short time before switching baudrate again, otherwise the zero byte won't be sent
         // with the lower baudrate
         sleep(Duration::from_millis(1));
@@ -98,7 +98,7 @@ impl driver::Master for SerialLin {
             Ok(())
         })?;
 
-        self.0.write(&[0x55, pid.get()])?;
+        self.0.write_all(&[0x55, pid.get()])?;
 
         let mut buf = [0; 2];
         self.0.read_exact(&mut buf)?;
@@ -119,7 +119,7 @@ impl driver::Master for SerialLin {
             data.len() <= 9,
             "Data must be at most 8 bytes + 1 checksum byte"
         );
-        self.0.write(data)?;
+        self.0.write_all(data)?;
         let mut buf = [0; 9];
         self.0.read_exact(&mut buf[0..data.len()])?;
         if &buf[0..data.len()] != data {


### PR DESCRIPTION
When using `write` one needs to handle the case where not all data is
written. This fixes a clippy reported problem:

    error: written amount is not handled. Use `Write::write_all` instead
      --> src/lib.rs:63:9
       |
    63 |         self.0.write(&[0])?;
       |         ^^^^^^^^^^^^^^^^^^^
       |
       = note: `#[deny(clippy::unused_io_amount)]` on by default
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount