### PR TITLE
Use 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["LIN", "local", "interconnect", "network", "serial"]
 categories = ["hardware-support"]
 license = "BSD-3-Clause"
 repository = "https://github.com/Sensirion/lin-bus-driver-serial-rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 lin-bus = "^0.4"

--- a/examples/read_frame.rs
+++ b/examples/read_frame.rs
@@ -1,5 +1,3 @@
-extern crate lin_bus_driver_serial;
-
 use lin_bus_driver_serial::lin_bus::{Master, PID};
 use lin_bus_driver_serial::serial;
 use lin_bus_driver_serial::SerialLin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub extern crate lin_bus;
-pub extern crate serial;
+pub use lin_bus;
+pub use serial;
 
 use lin_bus::{driver, PID};
 use serial::{SerialPort, SystemPort};


### PR DESCRIPTION
Rust 2021 got released with Rust 1.56. Since we require Rust 1.57
anyways we can opt in to the new edition, especially since no changes
are needed.
See https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#rust-2021